### PR TITLE
Revert "Remove AbstractString and use String"

### DIFF
--- a/src/matstr.jl
+++ b/src/matstr.jl
@@ -9,7 +9,7 @@ end
 DumbParserState() = DumbParserState(0, false)
 
 # Returns true if an = is encountered and updates pstate
-function dumb_parse!(pstate::DumbParserState, str::String)
+function dumb_parse!(pstate::DumbParserState, str::AbstractString)
     paren_depth = pstate.paren_depth
     in_string = pstate.in_string
     x = '\0'
@@ -52,9 +52,9 @@ end
 # assignment and use status
 function check_assignment(interp, i)
     # Go back to the last newline
-    before = String[]
+    before = AbstractString[]
     for j = i-1:-1:1
-        if isa(interp[j], String)
+        if isa(interp[j], AbstractString)
             sp = split(interp[j], "\n")
             unshift!(before, sp[end])
             for k = length(sp)-1:-1:1
@@ -70,10 +70,10 @@ function check_assignment(interp, i)
     (dumb_parse!(pstate, join(before)) || pstate.paren_depth > 1) && return (false, true)
 
     # Go until the next newline or comment
-    after = String[]
+    after = AbstractString[]
     both_sides = false
     for j = i+1:length(interp)
-        if isa(interp[j], String)
+        if isa(interp[j], AbstractString)
             sp = split(interp[j], "\n")
             push!(after, sp[1])
             for k = 2:length(sp)
@@ -94,7 +94,7 @@ end
 function do_mat_str(ex)
     # Hack to do interpolation
     interp = parse(string("\"\"\"", replace(ex, "\"\"\"", "\\\"\"\""), "\"\"\""))
-    if isa(interp, String)
+    if isa(interp, AbstractString)
         interp = [interp]
     elseif interp.head == :string
         interp = interp.args
@@ -111,7 +111,7 @@ function do_mat_str(ex)
     assignedvars = Set{Symbol}()
     varmap = Dict{Symbol,Symbol}()
     for i = 1:length(interp)
-        if !isa(interp[i], String)
+        if !isa(interp[i], AbstractString)
             # Don't put the same symbol to MATLAB twice
             if haskey(varmap, interp[i])
                 var = varmap[interp[i]]
@@ -142,7 +142,7 @@ function do_mat_str(ex)
     unshift!(interp, "clear ans;\nmatlab_jl_has_ans = 0;\n")
 
     # Add a semicolon to the end of the last statement to suppress output
-    isa(interp[end], String) && (interp[end] = rstrip(interp[end]))
+    isa(interp[end], AbstractString) && (interp[end] = rstrip(interp[end]))
     push!(interp, ";")
 
     # Figure out if `ans` exists in code to avoid an error if it doesn't

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -544,7 +544,7 @@ const _mx_get_string = mxfunc(:mxGetString_730)
 # use deep-copy from MATLAB variable to Julia array
 # in practice, MATLAB variable often has shorter life-cycle
 
-function _jarrayx(fun::String, mx::MxArray, siz::Tuple)
+function _jarrayx(fun::AbstractString, mx::MxArray, siz::Tuple)
     if is_numeric(mx) || is_logical(mx)
         @assert !is_sparse(mx)
         T = eltype(mx)
@@ -647,7 +647,7 @@ function jdict(mx::MxArray)
         throw(ArgumentError("jdict only applies to a single struct."))
     end
     nf = mxnfields(mx)
-    fnames = Array(String, nf)
+    fnames = Array(AbstractString, nf)
     fvals = Array(Any, nf)
     for i = 1:nf
         fnames[i] = get_fieldname(mx, i)
@@ -687,6 +687,7 @@ jvariable(mx::MxArray, ty::Type{Array})  = jarray(mx)
 jvariable(mx::MxArray, ty::Type{Vector}) = jvector(mx)
 jvariable(mx::MxArray, ty::Type{Matrix}) = jmatrix(mx)
 jvariable(mx::MxArray, ty::Type{Number}) = jscalar(mx)::Number
+jvariable(mx::MxArray, ty::Type{AbstractString}) = jstring(mx)::String
 jvariable(mx::MxArray, ty::Type{String}) = jstring(mx)::String
 jvariable(mx::MxArray, ty::Type{Dict}) = jdict(mx)
 jvariable(mx::MxArray, ty::Type{SparseMatrixCSC}) = jsparse(mx)

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -290,7 +290,7 @@ a = mxstruct(s)
 delete(a)
 
 type TestType
-    name::String
+    name::AbstractString
     version::Float64
     data::Vector{Int}
 end
@@ -366,7 +366,7 @@ a = Dict("abc"=>10.0, "efg"=>[1, 2, 3], "xyz"=>"MATLAB")
 x = mxarray(a)
 y = jvariable(x)
 delete(x)
-@test isa(y, Dict{String, Any})
+@test isa(y, Dict{AbstractString, Any})
 
 @test y["abc"] == 10.0
 @test isequal(y["efg"], [1, 2, 3])


### PR DESCRIPTION
This reverts commit 2f58a6b3482648466f350d0c6c1bd9a62976e179.

As per @yuyichao complaints.

I still think the tests should have different behavior. I.e. I find it troublesome  that
```julia
a = Dict("abc"=>10.0, "efg"=>[1, 2, 3], "xyz"=>"MATLAB")
x = mxarray(a)
y = jvariable(x)
delete(x)
@test isa(y, Dict{AbstractString, Any})
```
returns `Dict{AbstractString, Any}` instead of `Dict{String,Any}` . I don't quite fully understand the concerns, since I think it should return `Dicst{String,Any}`.


