### PR TITLE
Get rid of mxempty()

### DIFF
--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -15,7 +15,7 @@ export is_double, is_single,
        is_numeric, is_complex, is_sparse, is_empty,
        is_logical, is_char, is_struct, is_cell
 
-export mxarray, mxempty, mxsparse, delete, duplicate,
+export mxarray, mxsparse, delete,
        mxcellarray, get_cell, set_cell,
        mxstruct, mxstructarray, mxnfields, get_fieldname, get_field, set_field,
        jvariable, jarray, jscalar, jvector, jmatrix, jsparse, jstring, jdict
@@ -30,6 +30,7 @@ export MSession, MatFile,
        variable_names, read_matfile, write_matfile,
        mxcall,
        @mput, @mget, @matlab, @mat_str, @mat_mstr
+
 
 # exceptions
 type MEngineError <: Exception
@@ -69,5 +70,8 @@ function jvariable(mx::MxArray, ty::Type{AbstractString})
 end
 
 @deprecate duplicate(mx::MxArray) copy(mx::MxArray)
+
+@deprecate mxempty() mxarray(Float64,0,0)
+
 
 end

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -279,9 +279,6 @@ const _mx_set_field = mxfunc(:mxSetField_730)
 const _mx_get_field_bynum = mxfunc(:mxGetFieldByNumber_730)
 const _mx_get_fieldname = mxfunc(:mxGetFieldNameByNumber)
 
-# create zero arrays
-
-mxempty() = mxarray(Float64, 0, 0)
 
 function _dims_to_mwSize(dims::Tuple{Vararg{Int}})
     ndim = length(dims)

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -45,7 +45,7 @@ end
 
 # empty array
 
-a = mxempty()
+a = mxarray(Float64, 0, 0)
 @test nrows(a) == 0
 @test ncols(a) == 0
 @test nelems(a) == 0


### PR DESCRIPTION
How useful is this? Seems pointless to me.