### PR TITLE
Add possibility to run MATLAB in 'no desktop' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ By default, `MATLAB.jl` uses the MATLAB installation with the greatest version n
 
 ## Usage
 
+### Display
+
+If the ``DISPLAY`` environment variable is not set or if the ``MATLAB_NO_DISPLAY`` environment variable is set, MATLAB will be run in 'no display'/'no jvm' mode. This allows:
+
+1. To run matlab on a server without any display server
+
+2. Speedup the matlab session startup.
+
 ### MxArray class
 
 An instance of ``MxArray`` encapsulates a MATLAB variable. This package provides a series of functions to manipulate such instances.

--- a/src/mxbase.jl
+++ b/src/mxbase.jl
@@ -41,6 +41,12 @@ function get_paths()
             error("The MATLAB path is invalid. Set the MATLAB_HOME evironmental variable to the MATLAB root.")
         end
         default_startcmd = "exec $(Base.shell_escape(default_startcmd)) -nosplash"
+
+        # Disable DISPLAY if asked or not avaible
+        if get(ENV, "DISPLAY", nothing) == nothing ||
+            get(ENV, "MATLAB_NO_DISPLAY", nothing) != nothing
+            default_startcmd *= " -nodisplay -nojvm"
+        end
     elseif is_windows()
         default_startcmd = joinpath(matlab_homepath, "bin", (Sys.WORD_SIZE == 32 ? "win32" : "win64"), "MATLAB.exe")
         if !isfile(default_startcmd)


### PR DESCRIPTION
This change should automatically disable the jvm/desktop mode of MATLAB if there is no display server available (i.e. the `$DISPLAY` env var is not set) or if the user has set the `$MATLAB_NO_DISPLAY` var.