### PR TITLE
Ensure types are marshaled back correctly

### DIFF
--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -551,6 +551,11 @@ const _mx_get_string = mxfunc(:mxGetString_730)
 # use deep-copy from MATLAB variable to Julia array
 # in practice, MATLAB variable often has shorter life-cycle
 
+function same_type(xs::AbstractArray, T::Type)::Bool
+    S = eltype(xs)
+    return S == Any ? all(isa(element, T) for element in xs) : true
+end
+
 function _jarrayx(fun::String, mx::MxArray, siz::Tuple)
     if is_numeric(mx) || is_logical(mx)
         @assert !is_sparse(mx)
@@ -572,7 +577,8 @@ function _jarrayx(fun::String, mx::MxArray, siz::Tuple)
         for i = 1:length(a)
             a[i] = jvalue(get_cell(mx, i))
         end
-        return a
+        kind = typeof(first(a))
+        return same_type(a, kind) ? convert(Array{kind}, a) : a
     else
         throw(ArgumentError("$(fun) only applies to numeric, logical or cell arrays."))
     end

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -263,6 +263,7 @@ s = ["abc", "efg"]
 s_mx = mxcellarray(s)
 @test jstring(get_cell(s_mx, 1)) == "abc"
 @test jstring(get_cell(s_mx, 2)) == "efg"
+@test typeof(s) == typeof(jvalue(s_mx))
 delete(s_mx)
 
 # struct 


### PR DESCRIPTION
See additional added test, which fails before this.

What we do is check for a cellarray that all the types are the same and if so convert it to the common type

```julia

julia> s = ["abc", "efg"]
2-element Array{String,1}:
 "abc"
 "efg"

julia> sa = Any["abc", "efg"]
2-element Array{Any,1}:
 "abc"
 "efg"

julia> sp = mxcellarray(s)

julia> sap = mxcellarray(sa)

julia> jvalue(sp)
2-element Array{String,1}:
 "abc"
 "efg"

julia> jvalue(sap)
2-element Array{String,1}:
 "abc"
 "efg"

```
Previously (under conversion to and from matlab)
- `Any[]` remains `Any[]` 
- `String[]`  returns back `Any[]`  

Now (under conversion to and from matlab)
- `Any[]` remains `Any[]` 
    - except if    all the element types are the same  e.g. `s = Any["dsf","dsf"]` which would spit back `String[]` 
- `String[]`  returns  `String[]`
  

Do you all think this is better behavior? If not I can close.




