### PR TITLE
Improve initializiation of libraries

### DIFF
--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -48,12 +48,11 @@ include("matstr.jl")
 
 function __init__()
     if is_windows()
-        global persistent_msession
         # workaround "primary message table for module 77" error
         # creates a dummy Engine session and keeps it open so the libraries used by all other
         # Engine clients are not loaded and unloaded repeatedly
         # see: https://www.mathworks.com/matlabcentral/answers/305877-what-is-the-primary-message-table-for-module-77
-        persistent_msession = MSession(0)
+        global const persistent_msession = MSession(0)
     end
 end
 
@@ -75,6 +74,5 @@ end
 @deprecate duplicate(mx::MxArray) copy(mx::MxArray)
 
 @deprecate mxempty() mxarray(Float64,0,0)
-
 
 end

--- a/src/mxbase.jl
+++ b/src/mxbase.jl
@@ -1,103 +1,74 @@
-libmx = C_NULL
-libeng = C_NULL
-libmat = C_NULL
-
 # Determine MATLAB library path and provide facilities to load libraries with
 # this path
 
 function get_paths()
-    global matlab_homepath = get(ENV, "MATLAB_HOME", "")
-    global default_startcmd = C_NULL
-    global matlab_library_path = nothing
+    matlab_home = get(ENV, "MATLAB_HOME", "")
 
-    if matlab_homepath == ""
+    if matlab_home == ""
         if is_linux()
-            matlab_homepath = dirname(dirname(realpath(chomp(readstring(`which matlab`)))))
+            matlab_home = dirname(dirname(realpath(chomp(readstring(`which matlab`)))))
         elseif is_apple()
-            apps = readdir("/Applications")
-            filter!(app -> ismatch(r"^MATLAB_R[0-9]+[ab]\.app$", app), apps)
-            if ~isempty(apps)
-                matlab_homepath = joinpath("/Applications", maximum(apps))
+            default_dir = "/Applications"
+            if isdir(default_dir)
+                dirs = readdir(default_dir)
+                filter!(app -> ismatch(r"^MATLAB_R[0-9]+[ab]\.app$", dirs), dirs)
             end
         elseif is_windows()
             default_dir = Sys.WORD_SIZE == 32 ? "C:\\Program Files (x86)\\MATLAB" : "C:\\Program Files\\MATLAB"
             if isdir(default_dir)
                 dirs = readdir(default_dir)
                 filter!(dir -> ismatch(r"^R[0-9]+[ab]$", dir), dirs)
-                if ~isempty(dirs)
-                    matlab_homepath = joinpath(default_dir, maximum(dirs))
-                end
             end
         end
     end
 
-    if matlab_homepath == ""
+    if ~isempty(dirs)
+        matlab_home = joinpath(default_dir, maximum(dirs))
+    end
+    if matlab_home == ""
         error("The MATLAB path could not be found. Set the MATLAB_HOME environmental variable to specify the MATLAB path.")
     end
 
     if !is_windows()
-        default_startcmd = joinpath(matlab_homepath, "bin", "matlab")
+        default_startcmd = joinpath(matlab_home, "bin", "matlab")
         if !isfile(default_startcmd)
             error("The MATLAB path is invalid. Set the MATLAB_HOME evironmental variable to the MATLAB root.")
         end
-        default_startcmd = "exec $(Base.shell_escape(default_startcmd)) -nosplash"
+        default_startcmd = "exec $(Base.shell_escape(default_startcmd))"
     elseif is_windows()
-        default_startcmd = joinpath(matlab_homepath, "bin", (Sys.WORD_SIZE == 32 ? "win32" : "win64"), "MATLAB.exe")
+        default_startcmd = joinpath(matlab_home, "bin", (Sys.WORD_SIZE == 32 ? "win32" : "win64"), "MATLAB.exe")
         if !isfile(default_startcmd)
             error("The MATLAB path is invalid. Set the MATLAB_HOME evironmental variable to the MATLAB root.")
         end
-        default_startcmd *= " -nosplash"
     end
+    default_startcmd *= " -nosplash"
 
     # Get path to MATLAB libraries
-    if is_linux()
-        matlab_library_dir = Sys.WORD_SIZE == 32 ? "glnx86" : "glnxa64"
+    matlab_lib_dir = if is_linux()
+        Sys.WORD_SIZE == 32 ? "glnx86" : "glnxa64"
     elseif is_apple()
-        matlab_library_dir = Sys.WORD_SIZE == 32 ? "maci" : "maci64"
+        Sys.WORD_SIZE == 32 ? "maci" : "maci64"
     elseif is_windows()
-        matlab_library_dir = Sys.WORD_SIZE == 32 ? "win32" : "win64"
+        Sys.WORD_SIZE == 32 ? "win32" : "win64"
     end
-    matlab_library_path = joinpath(matlab_homepath, "bin", matlab_library_dir)
+    matlab_lib_path = joinpath(matlab_home, "bin", matlab_lib_dir)
+    if !isdir(matlab_lib_path)
+        error("The MATLAB library path could not be found.")
+    end
 
-    if matlab_library_path != nothing && !isdir(matlab_library_path)
-        matlab_library_path = nothing
-    end
+    return default_startcmd, matlab_lib_path
 end
-get_paths()
 
-matlab_library(lib::String) = matlab_library_path == nothing ? lib : joinpath(matlab_library_path, lib)
+default_startcmd, matlab_lib_path = get_paths()
 
-# libmx (loaded when the module is imported)
+const libmx = dlopen(joinpath(matlab_lib_path, "libmx"), RTLD_GLOBAL)
+@assert libmx != C_NULL
 
-function load_libmx()
-    global libmx
-    if libmx == C_NULL
-        libmx = dlopen(matlab_library("libmx"), RTLD_GLOBAL | RTLD_LAZY)
-        libmx == C_NULL && error("Failed to load libmx.")
-    end
-end
-load_libmx()
+const libmat = dlopen(joinpath(matlab_lib_path, "libmat"), RTLD_GLOBAL)
+@assert libmat != C_NULL
 
-# libmat (loaded when the module is imported)
-
-function load_libmat()
-    global libmat
-    if libmat == C_NULL
-        libmat = dlopen(matlab_library("libmat"), RTLD_GLOBAL | RTLD_LAZY)
-        libmat == C_NULL && error("Failed to load libmat.")
-    end
-end
-load_libmat()
-
-# libeng (loaded when needed)
-
-function load_libeng()
-    global libeng
-    if libeng == C_NULL
-        libeng = dlopen(matlab_library("libeng"), RTLD_GLOBAL | RTLD_LAZY)
-        libeng == C_NULL && error("Failed to load libeng.")
-    end
-end
+const libeng = dlopen(joinpath(matlab_lib_path, "libeng"), RTLD_GLOBAL)
+@assert libeng != C_NULL
 
 engfunc(fun::Symbol) = dlsym(libeng::Ptr{Void}, fun)
 mxfunc(fun::Symbol) = dlsym(libmx::Ptr{Void}, fun)


### PR DESCRIPTION
There really isn't any point in having them initialized as C_NULL's etc. Same with the other globals that are initialized to nothing. If we can't find the appropriate files/folders it will error anyways. 