### PR TITLE
Clean up unsafe_string

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -115,11 +115,9 @@ function eval_string(session::MSession, stmt::String)
     ret != 0 && throw(MEngineError("invalid engine session (err = $ret)"))
 
     bufptr = session.bufptr
-    if bufptr != C_NULL
-        bs = unsafe_string(bufptr)
-        if ~isempty(bs)
-            print(bs)
-        end
+    bs = unsafe_string(bufptr)
+    if ~isempty(bs)
+        print(bs)
     end
     return nothing
 end


### PR DESCRIPTION
If the engine  session doesn't exist then  it will error with UndefVar   on line 114