### PR TITLE
fixed MATLAB home path finding for OSX

### DIFF
--- a/src/mxbase.jl
+++ b/src/mxbase.jl
@@ -10,7 +10,7 @@ function matlab_home_path()
             default_dir = "/Applications"
             if isdir(default_dir)
                 dirs = readdir(default_dir)
-                filter!(app -> ismatch(r"^MATLAB_R[0-9]+[ab]\.app$", dirs), dirs)
+                filter!(app -> ismatch(r"^MATLAB_R[0-9]+[ab]\.app$", app), dirs)
                 if ~isempty(dirs)
                     matlab_home = joinpath(default_dir, maximum(dirs))
                 end


### PR DESCRIPTION
Instead of a string (`app`) a complete array (`dirs`) was passed to the `ismatch` function which caused a runtime error.