### PR TITLE
Hold default MSession as a const Ref and Lazy initialize Windows engine to match Linux and Mac

### DIFF
--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -46,6 +46,24 @@ include("matfile.jl")
 include("engine.jl")
 include("matstr.jl")
 
+if iswindows()
+    # workaround "primary message table for module 77" error
+    # creates a dummy Engine session and keeps it open so the libraries used by all other
+    # Engine clients are not loaded and unloaded repeatedly
+    # see: https://www.mathworks.com/matlabcentral/answers/305877-what-is-the-primary-message-table-for-module-77
+
+    # initialization is delayed untill first call to MSession
+    const persistent_msession_ref = Ref{MSession}()
+    const persistent_msession_assigned = Ref(false) 
+
+    function assign_persistent_msession()
+        if persistent_msession_assigned[] == false
+            persistent_msession_assigned[] = true
+            persistent_msession_ref[] = MSession(0)
+        end
+    end
+end
+
 function __init__()
 
     # initialize library paths
@@ -151,14 +169,6 @@ function __init__()
     mat_put_variable[] = matfunc(:matPutVariable)
     mat_get_dir[]      = matfunc(:matGetDir)
 
-
-    if iswindows()
-        # workaround "primary message table for module 77" error
-        # creates a dummy Engine session and keeps it open so the libraries used by all other
-        # Engine clients are not loaded and unloaded repeatedly
-        # see: https://www.mathworks.com/matlabcentral/answers/305877-what-is-the-primary-message-table-for-module-77
-        global persistent_msession = MSession(0)
-    end
 end
 
 

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -72,31 +72,26 @@ end
 
 # default session
 
-default_msession = nothing
+const default_msession_ref = Ref{MSession}()
+
+# this function will start an MSession if default_msession_ref is undefined or if the
+# MSession has been closed so that the engine ptr is void
+function get_default_msession()
+    if !isassigned(default_msession_ref) || default_msession_ref[].ptr == C_NULL
+        default_msession_ref[] = MSession()
+    end
+    return default_msession_ref[]
+end
 
 function restart_default_msession(bufsize::Integer = default_output_buffer_size)
-    global default_msession
-    if default_msession !== nothing && default_msession.ptr != C_NULL
-        close(default_msession)
-    end
-    default_msession = MSession(bufsize)
+    close_default_msession()
+    default_msession_ref[] = MSession(bufsize)
     return nothing
 end
 
-
-function get_default_msession()
-    global default_msession
-    if default_msession === nothing
-        default_msession = MSession()
-    end
-    return default_msession::MSession
-end
-
 function close_default_msession()
-    global default_msession
-    if default_msession !== nothing
-        close(default_msession)
-        default_msession = nothing
+    if isassigned(default_msession_ref) && default_msession_ref[].ptr !== C_NULL
+        close(default_msession_ref[])
     end
     return nothing
 end

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -16,6 +16,10 @@ mutable struct MSession
     bufptr::Ptr{UInt8}
 
     function MSession(bufsize::Integer = default_output_buffer_size)
+        if iswindows()
+            assign_persistent_msession()
+        end
+        
         ep = ccall(eng_open[], Ptr{Cvoid}, (Ptr{UInt8},), default_startcmd)
         if ep == C_NULL
             @warn "Confirm MATLAB is installed and discoverable."


### PR DESCRIPTION
Last 2 commits

1. Hold default msession as a Ref instead of a untyped global 
2. Lazy initialize the persistent engine on windows until the first call to MSession
