### PR TITLE
Fix segfault on Linux

### DIFF
--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -312,7 +312,7 @@ function _copy_sparse_mat(a::SparseMatrixCSC{V,I}, ir_p::Ptr{mwIndex}, jc_p::Ptr
         jc[i] = colptr[i] - 1
     end
 
-    ccall(:memcpy, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, UInt), pr_p, v, nnz*sizeof(V))
+    copyto!(unsafe_wrap(Array, pr_p, (nnz,)), v)
 end
 
 function mxarray(a::SparseMatrixCSC{V,I}) where {V<:Union{Float64,Bool},I}


### PR DESCRIPTION
It seems to fix the segfault issue. This ends up calling `unsafe_copyto!`: https://github.com/JuliaLang/julia/blob/8221c87b09b8456f4fe422ee2d8756a2a2630c7b/base/array.jl#L240
which also calls optimized C-function to do the copy so it might be easier and as efficient to call `copyto!` instead of `memcpy`.

Closes https://github.com/JuliaInterop/MATLAB.jl/issues/142