### PR TITLE
Add custom REPL prompt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,10 +2,11 @@ name = "MATLAB"
 uuid = "10e44e05-a98a-55b3-a45b-ba969058deb6"
 repo = "https://github.com/JuliaInterop/MATLAB.jl.git"
 license = "MIT"
-version = "v0.7.0"
+version = "v0.8.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]

--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -2,6 +2,7 @@ module MATLAB
 
 using Base.Sys: islinux, iswindows, isapple
 using Libdl
+using ReplMaker
 using SparseArrays
 
 import Base: eltype, close, size, copy, ndims, unsafe_convert
@@ -45,6 +46,7 @@ include("mxarray.jl")
 include("matfile.jl")
 include("engine.jl")
 include("matstr.jl")
+# include("repl.jl")
 
 if iswindows()
     # workaround "primary message table for module 77" error
@@ -166,6 +168,14 @@ function __init__()
     mat_put_variable[] = matfunc(:matPutVariable)
     mat_get_dir[]      = matfunc(:matGetDir)
 
+    
+    if isinteractive()
+        initrepl(str -> Meta.parse("MATLAB.replmat\"$str\"");
+            prompt_text = ">> ",
+            start_key = ">",
+        mode_name = "MATLAB-Mode",
+        )
+    end
 end
 
 

--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -46,7 +46,6 @@ include("mxarray.jl")
 include("matfile.jl")
 include("engine.jl")
 include("matstr.jl")
-# include("repl.jl")
 
 if iswindows()
     # workaround "primary message table for module 77" error
@@ -173,7 +172,7 @@ function __init__()
         initrepl(str -> Meta.parse("MATLAB.replmat\"$str\"");
             prompt_text = ">> ",
             start_key = ">",
-        mode_name = "MATLAB-Mode",
+            mode_name = "MATLAB-Mode",
         )
     end
 end


### PR DESCRIPTION
First shot at a version of a custom REPL prompt that allows Julia variable interpolation but still prints outputs based on #175. Using `do_mat_str` for this, so had to add a couple of branches in there to suppress double printing of `ans` while still allowing of for regular output printing.