### PR TITLE
Registered trademark

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `MATLAB.jl` package provides an interface for using [MATLAB®](http://www.mathworks.com/products/matlab/) from [Julia](http://julialang.org) using the MATLAB C api.  In other words, this package allows users to call MATLAB functions within Julia, thus making it easy to interoperate with MATLAB from the Julia language.
 
-You cannot use `MATLAB.jl` without having purchased and installed a copy of MATLABfrom [MathWorks](http://www.mathworks.com/). This package is available free of charge and in no way replaces or alters any functionality of MathWorks's MATLAB product.
+You cannot use `MATLAB.jl` without having purchased and installed a copy of MATLAB® from [MathWorks](http://www.mathworks.com/). This package is available free of charge and in no way replaces or alters any functionality of MathWorks's MATLAB product.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## MATLAB
 
-The `MATLAB.jl` package provides an interface for using [MATLAB™](http://www.mathworks.com/products/matlab/) from [Julia](http://julialang.org) using the MATLAB C api.  In other words, this package allows users to call MATLAB functions within Julia, thus making it easy to interoperate with MATLAB from the Julia language.
+The `MATLAB.jl` package provides an interface for using [MATLAB®](http://www.mathworks.com/products/matlab/) from [Julia](http://julialang.org) using the MATLAB C api.  In other words, this package allows users to call MATLAB functions within Julia, thus making it easy to interoperate with MATLAB from the Julia language.
 
-You cannot use `MATLAB.jl` without having purchased and installed a copy of MATLAB™ from [MathWorks](http://www.mathworks.com/). This package is available free of charge and in no way replaces or alters any functionality of MathWorks's MATLAB product.
+You cannot use `MATLAB.jl` without having purchased and installed a copy of MATLABfrom [MathWorks](http://www.mathworks.com/). This package is available free of charge and in no way replaces or alters any functionality of MathWorks's MATLAB product.
 
 ## Overview
 


### PR DESCRIPTION
[skip ci]

MATLAB also uses in some cases TM (i.e not registered), but that seems wrong in this case.

FYI: I thought conversely TM right for Python.jl, but that's for the logo only. There's a discussion about registering that package, pointing to this one as precedent (while also thought the name here not ideal...). ® is maybe not required for Python (in that case), but might be best to be on the safe side, here I think we really want o be right:

https://se.mathworks.com/company/aboutus/policies_statements/trademarks.html

https://github.com/JuliaRegistries/General/pull/30700