### PR TITLE
Test matlab gh actions CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,10 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
+      - name: Install csh
+        run: sudo apt-get install csh
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v0
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -84,10 +84,9 @@ if !isnothing(matlab_root)
             println(io, "const matlab_cmd = \"$(escape_string(matlab_cmd))\"")
             println(io, "const libmx_size = $libmx_size")
     end
-elseif get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", nothing) == "true" || get(ENV, "CI", nothing) == "true"
+elseif get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", nothing) == "true"
     # We need to be able to install and load this package without error for
     # Julia's registry AutoMerge to work, so we just use dummy values.
-    # Similarly we want to also be able to install and load this package for CI.
     matlab_libpath = ""
     matlab_cmd = ""
     libmx_size = 0

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -23,8 +23,10 @@ mutable struct MSession
         if Sys.iswindows()
             assign_persistent_msession()
         end
-        ep = ccall(eng_open[], Ptr{Cvoid}, (Ptr{UInt8},), startcmd(flags))
+        ep = ccall(eng_open[], Ptr{Cvoid}, (Ptr{UInt8},), C_NULL)
         if ep == C_NULL
+            @show eng_open[]
+            @show matlab_libpath
             @warn("Confirm MATLAB is installed and discoverable.", maxlog=1)
             if Sys.iswindows()
                 @warn("Ensure `matlab -regserver` has been run in a Command Prompt as Administrator.", maxlog=1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,7 @@
 using MATLAB
 using Test
 
-is_ci() = get(ENV, "CI", nothing) == "true"
-
-if !is_ci() # only test if not CI
 include("engine.jl")
 include("matfile.jl")
 include("matstr.jl")
 include("mxarray.jl")
-end


### PR DESCRIPTION
The matlab CI is only available on the Linux platform.

Ref:  https://github.com/matlab-actions/setup-matlab/#set-up-matlab