### PR TITLE
read symlink instead of ignoring it

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -8,7 +8,8 @@ function find_matlab_root()
                         get(ENV, "MATLAB_HOME", nothing))
     if isnothing(matlab_root)
         matlab_exe = Sys.which("matlab")
-        if !isnothing(matlab_exe) && !islink(matlab_exe) # guard against /usr/local 
+        if !isnothing(matlab_exe)
+            matlab_exe = islink(matlab_exe) ? readlink(matlab_exe) : matlab_exe # guard against /usr/local 
             matlab_root = dirname(dirname(matlab_exe))
         else
             if Sys.isapple()


### PR DESCRIPTION
Seems like this approach would be more reliable.  Is there any reason not to adopt this approach?