### PR TITLE
Update build.jl to support aa64 macs

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -50,7 +50,8 @@ function find_matlab_libpath(matlab_root)
     matlab_libdir = if Sys.islinux()
         Sys.WORD_SIZE == 32 ? "glnx86" : "glnxa64"
     elseif Sys.isapple()
-        Sys.WORD_SIZE == 32 ? "maci" : "maci64"
+        archchar = Sys.ARCH == :aarch64 ? "a" : "i"
+        Sys.WORD_SIZE == 32 ? "maci" : "mac" * archchar * "64"
     elseif Sys.iswindows()
         Sys.WORD_SIZE == 32 ? "win32" : "win64"
     end


### PR DESCRIPTION
I saw that `build.jl` was looking for the library `libmx` at the wrong subdirectory `maci64` instead of the correct one `maca64` foat the `aa64` version of `MATLAB`

With this change `MATLAB.jl` builds correctly and all tests passed. It fixes #205 #209 

*Clarification*: This should allow MATLAB.jl to build and work correctly for macOS julia-x86 with MATLAB-x86 and julia-aa64 with MATLAB-aa64 (like the R2023b Prerelease). I do not believe that other combinations are possible (or meaningful?).