### PR TITLE
The segfault issue with MATLAB versions 2022/2023 is gone on Linux platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ## MATLAB
 
-
-| :exclamation:  ** MATLAB versions 2022 and 2023 trigger a segfault and do not work with `MATLAB.jl`. Maintainers are attempting to diagnose the cause and fix the issue. **  |
-|-----------------------------------------|
+| :white_check_mark: ** MATLAB versions 2022 and 2023 now work with `MATLAB.jl`.** |
+|----------------------------------------------------------------------------------|
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## MATLAB
 
-| :white_check_mark: ** MATLAB versions 2022 and 2023 now work with `MATLAB.jl`.** |
+| :white_check_mark: ** MATLAB versions 2022 and 2023 now work with `MATLAB.jl` ** <br/> If you experience a segfault when starting the MATLAB engine, try to [update](https://se.mathworks.com/help/matlab/matlab_env/check-for-software-updates.html) your MATLAB release |
 |----------------------------------------------------------------------------------|
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## MATLAB
 
-| ❗ Windows and MacOS platforms : MATLAB versions R2022 and R2023 do not work with `MATLAB.jl`. ❗ |
+| ❗ Windows and MacOS platforms : MATLAB versions R2022 and R2023 do not work with `MATLAB.jl` ❗ <br/> You can use older versions as explained [further down](https://github.com/JuliaInterop/MATLAB.jl#changing_matlab_version). |
 |:----:|
 
 | ❗ Linux platforms : If you experience problems when starting the MATLAB engine with versions R2022 or R2023, try to [update](https://se.mathworks.com/help/matlab/matlab_env/check-for-software-updates.html) your MATLAB release. |
@@ -31,8 +31,6 @@ This package is composed of two aspects:
 
 **Important**: The procedure to setup this package consists of the following steps.
 
-By default, `MATLAB.jl` uses the MATLAB installation with the greatest version number. To specify that a specific MATLAB installation should be used, set the environment variable `MATLAB_ROOT`.
-
 ### Windows
 
 1. For Matlab R2020a onwards, you should be able to go directly to step 2. If you encounter issues, run `matlab -batch "comserver('register')"` in the command prompt. For earlier versions of Matlab, start a command prompt as an administrator and enter `matlab /regserver`.
@@ -60,6 +58,24 @@ By default, `MATLAB.jl` uses the MATLAB installation with the greatest version n
 1. Ensure that MATLAB is installed in `/Applications` (for example, if you are using MATLAB R2012b, you may add the following command to `.profile`:  `export MATLAB_HOME=/Applications/MATLAB_R2012b.app`).
 
 2. From Julia run: `Pkg.add("MATLAB")`
+
+
+## Changing MATLAB version
+
+By default, `MATLAB.jl` is built using the MATLAB installation with the greatest version number. To specify that a specific MATLAB installation should be used, set the environment variable `MATLAB_ROOT`:
+```julia
+julia> ENV["MATLAB_ROOT"] = "/usr/local/MATLAB/R2021b" # example on a Linux machine
+```
+```julia
+julia> ENV["MATLAB_ROOT"] = raw"C:\Program Files\MATLAB\R2021b" # example on a Windows machine
+```
+Replace the path string with the location of the MATLAB folder on your machine. You need to set the path to the `R20XX` folder, not the `matlab` binary.
+
+If you had the package `MATLAB.jl` already installed and built before changing the environment variable, you will need to rebuild it to apply the change:
+```julia
+julia> using Pkg; Pkg.build("MATLAB")
+```
+
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ## MATLAB
 
-| :white_check_mark: ** MATLAB versions 2022 and 2023 now work with `MATLAB.jl` ** <br/> If you experience a segfault when starting the MATLAB engine, try to [update](https://se.mathworks.com/help/matlab/matlab_env/check-for-software-updates.html) your MATLAB release |
-|----------------------------------------------------------------------------------|
+| ❗ Windows and MacOS platforms : MATLAB versions R2022 and R2023 do not work with `MATLAB.jl`. ❗ |
+|:----:|
+
+| ❗ Linux platforms : If you experience problems when starting the MATLAB engine with versions R2022 or R2023, try to [update](https://se.mathworks.com/help/matlab/matlab_env/check-for-software-updates.html) your MATLAB release. |
+|:----:|
 
 
 


### PR DESCRIPTION
I noticed today that `MATLAB.jl` works perfectly with the new version of MATLAB R2023b.

By curiosity I also checked the former 'problematic' versions (R2023a, R2022b, R2022a) and they all work on my computer. I suspect some update of internals on the MATLAB side: all three versions have received updates in July/August of this year (as can be seen [here](https://se.mathworks.com/downloads/)).

Here is what I manage to get in the REPL:
```julia
julia> mat"version"
"9.12.0.2327980 (R2022a) Update 7"
```

```julia
julia> mat"version"
"9.13.0.2320565 (R2022b) Update 6"
```

```julia
julia> mat"version"
"9.14.0.2337262 (R2023a) Update 5"
```

```julia
julia> mat"version"
"23.2.0.2365128 (R2023b)"
```


So now I don't know what is preferred: removing completely the warning message in README.md, or updating it to inform everything is working as normal now and keeping it for some time :slightly_smiling_face: 

p.s: this should close issues #200 and #201 :tada: 