### PR TITLE
Move the warning for Linux into the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 | ❗ Windows and MacOS platforms : MATLAB versions R2022 and R2023 do not work with `MATLAB.jl` ❗ <br/> You can use older versions as explained [further down](https://github.com/JuliaInterop/MATLAB.jl#changing_matlab_version). |
 |:----:|
 
-| ❗ Linux platforms : If you experience problems when starting the MATLAB engine with versions R2022 or R2023, try to [update](https://se.mathworks.com/help/matlab/matlab_env/check-for-software-updates.html) your MATLAB release. |
-|:----:|
-
-
-
 The `MATLAB.jl` package provides an interface for using [MATLAB®](http://www.mathworks.com/products/matlab/) from [Julia](http://julialang.org) using the MATLAB C api.  In other words, this package allows users to call MATLAB functions within Julia, thus making it easy to interoperate with MATLAB from the Julia language.
 
 You cannot use `MATLAB.jl` without having purchased and installed a copy of MATLAB® from [MathWorks](http://www.mathworks.com/). This package is available free of charge and in no way replaces or alters any functionality of MathWorks's MATLAB product.
@@ -51,6 +46,9 @@ This package is composed of two aspects:
 	```
 
 3. From Julia run: `Pkg.add("MATLAB")`
+
+
+If you experience problems when starting the MATLAB engine with versions R2022 or R2023, try to [update](https://se.mathworks.com/help/matlab/matlab_env/check-for-software-updates.html) your MATLAB release.
 
 
 ### Mac OS X


### PR DESCRIPTION
Feels a little less aggressive, especially since it should now work on Linux as long as an updated MATLAB version is being maintained.