### PR TITLE
Pass MATLAB flags that avoids some of the GUI-related things

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -5,8 +5,8 @@
 #   Session open & close
 #
 ###########################################################
-const default_startflag = "" # no additional flags
-const default_matlabcmd = matlab_cmd * " -nosplash"
+const default_startflag = "-nodisplay -nosplash -nodesktop" # no additional flags
+const default_matlabcmd = matlab_cmd * " -nodisplay -nosplash -nodesktop"
 # pass matlab flags directly or as a Vector of flags, i.e. "-a" or ["-a", "-b", "-c"]
 startcmd(flag::AbstractString = default_startflag) = isempty(flag) ? default_matlabcmd : default_matlabcmd * " " * flag
 startcmd(flags::AbstractVector{<:AbstractString}) = isempty(flags) ? default_matlabcmd : default_matlabcmd * " " * join(flags, " ")


### PR DESCRIPTION
I am currently working with MATLAB R2023b (update:7) on macbook, which despite the warnings in the `README.md` seems to work just fine for the basic interop functionalities that I am using.

However, the start of the session always starts the MATLAB app in the sense that the app icon pops up on the dock even if there isn't actually anything shown. I figured that with some extra flags it can be completely silenced, and it's probably what a user would want when interfacing from Julia anyway (i.e. just execute the operations within the engine, without visibly starting up an actual application instance).

Let me know if the current behaviour is intended.