### PR TITLE
Add conversion from AbstractArray to mxarray

### DIFF
--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -264,16 +264,6 @@ function mxarray(a::Array{T}) where T<:MxRealNum
     return mx
 end
 
-function mxarray(a::AbstractVecOrMat{T}) where {T<:MxRealNum}
-    mx = mxarray(T, size(a))
-    ptr = data_ptr(mx)
-    na = length(a)
-    dat = unsafe_wrap(Array{T}, ptr, na)
-    for (i, ix) in enumerate(eachindex(a))
-        dat[i] = a[ix]
-    end
-    return mx
-end
 
 function mxarray(a::Array{T}) where {T<:MxComplexNum}
     mx = mxarray(T, size(a))
@@ -287,8 +277,30 @@ function mxarray(a::Array{T}) where {T<:MxComplexNum}
     mx
 end
 
-mxarray(a::BitArray) = mxarray(convert(Array{Bool}, a))
-mxarray(a::AbstractRange) = mxarray([a;])
+
+function mxarray(a::AbstractVecOrMat{T}) where {T<:MxRealNum}
+    mx = mxarray(T, size(a))
+    ptr = data_ptr(mx)
+    na = length(a)
+    dat = unsafe_wrap(Array{T}, ptr, na)
+    for (i, ix) in enumerate(eachindex(a))
+        dat[i] = a[ix]
+    end
+    return mx
+end
+
+function mxarray(a::AbstractVecOrMat{T}) where {T<:MxComplexNum}
+    mx = mxarray(T, size(a))
+    na = length(a)
+    rdat = unsafe_wrap(Array, real_ptr(mx), na)
+    idat = unsafe_wrap(Array, imag_ptr(mx), na)
+    for (i, ix) in enumerate(eachindex(a))
+        rdat[i] = real(a[ix])
+        idat[i] = imag(a[ix])
+    end
+    return mx
+end
+
 
 # sparse matrix
 

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -278,7 +278,7 @@ function mxarray(a::Array{T}) where {T<:MxComplexNum}
 end
 
 
-function mxarray(a::AbstractVecOrMat{T}) where {T<:MxRealNum}
+function mxarray(a::AbstractArray{T}) where {T<:MxRealNum}
     mx = mxarray(T, size(a))
     ptr = data_ptr(mx)
     na = length(a)
@@ -289,7 +289,7 @@ function mxarray(a::AbstractVecOrMat{T}) where {T<:MxRealNum}
     return mx
 end
 
-function mxarray(a::AbstractVecOrMat{T}) where {T<:MxComplexNum}
+function mxarray(a::AbstractArray{T}) where {T<:MxComplexNum}
     mx = mxarray(T, size(a))
     na = length(a)
     rdat = unsafe_wrap(Array, real_ptr(mx), na)

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -264,7 +264,18 @@ function mxarray(a::Array{T}) where T<:MxRealNum
     return mx
 end
 
-function mxarray(a::Array{T}) where T<:MxComplexNum
+function mxarray(a::AbstractVecOrMat{T}) where {T<:MxRealNum}
+    mx = mxarray(T, size(a))
+    ptr = data_ptr(mx)
+    na = length(a)
+    dat = unsafe_wrap(Array{T}, ptr, na)
+    for (i, ix) in enumerate(eachindex(a))
+        dat[i] = a[ix]
+    end
+    return mx
+end
+
+function mxarray(a::Array{T}) where {T<:MxComplexNum}
     mx = mxarray(T, size(a))
     na = length(a)
     rdat = unsafe_wrap(Array, real_ptr(mx), na)

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -362,14 +362,6 @@ delete(a_mx)
 @test a == a_jl
 @test isa(a_jl, SparseMatrixCSC{Complex{Float64}})
 
-a = transpose(rand(10)) # transpose -> row vec
-x = mxarray(a)
-y = jvalue(x)
-delete(x)
-@test isa(y, Array{Float64,2})
-@test size(y) == size(a)
-@test isequal(y, a)
-
 ##############################
 # Abstract Array Conversions
 ##############################
@@ -391,11 +383,12 @@ delete(x)
 @test size(y) == size(a_)
 @test isequal(y, a_)
 
-a = rand(ComplexF32,10,10)
+a_ = rand(ComplexF32, 10, 10, 10)
+a = @view a_[3:7, 4:8, 2:5]
 x = mxarray(a)
 y = jvalue(x)
 delete(x)
-@test isa(y, Array{ComplexF32,2})
+@test isa(y, Array{ComplexF32,3})
 @test size(y) == size(a)
 
 a = 1:100 # range
@@ -405,11 +398,11 @@ delete(x)
 @test isa(y, Array{Int64,1})
 @test isequal(y, collect(a))
 
-a = BitMatrix(rand(Bool, 20,20))
+a = BitArray(rand(Bool, 5,20,10))
 x = mxarray(a)
 y = jvalue(x)
 delete(x)
-@test isa(y, Matrix{Bool})
+@test isa(y, Array{Bool,3})
 @test isequal(y, a)
 
 

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -1,5 +1,6 @@
 using MATLAB
 using Test
+using SparseArrays
 
 # Unit testing for MxArray
 
@@ -368,6 +369,54 @@ delete(x)
 @test isa(y, Array{Float64,2})
 @test size(y) == size(a)
 @test isequal(y, a)
+
+##############################
+# Abstract Array Conversions
+##############################
+
+a = transpose(rand(10))
+x = mxarray(a)
+y = jvalue(x)
+delete(x)
+@test isa(y, Array{Float64,2})
+@test size(y) == size(a)
+@test isequal(y, a)
+
+a = rand(10,10)
+a_ = @view a[3:7, 4:8]
+x = mxarray(a_)
+y = jvalue(x)
+delete(x)
+@test isa(y, Array{Float64,2})
+@test size(y) == size(a_)
+@test isequal(y, a_)
+
+a = rand(ComplexF32,10,10)
+x = mxarray(a)
+y = jvalue(x)
+delete(x)
+@test isa(y, Array{ComplexF32,2})
+@test size(y) == size(a)
+
+a = 1:100 # range
+x = mxarray(a)
+y = jvalue(x)
+delete(x)
+@test isa(y, Array{Int64,1})
+@test isequal(y, collect(a))
+
+a = BitMatrix(rand(Bool, 20,20))
+x = mxarray(a)
+y = jvalue(x)
+delete(x)
+@test isa(y, Matrix{Bool})
+@test isequal(y, a)
+
+
+
+##############################
+# String Conversions
+##############################
 
 a = "MATLAB"
 x = mxarray(a)

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -361,6 +361,14 @@ delete(a_mx)
 @test a == a_jl
 @test isa(a_jl, SparseMatrixCSC{Complex{Float64}})
 
+a = transpose(rand(10)) # transpose -> row vec
+x = mxarray(a)
+y = jvalue(x)
+delete(x)
+@test isa(y, Array{Float64,2})
+@test size(y) == size(a)
+@test isequal(y, a)
+
 a = "MATLAB"
 x = mxarray(a)
 y = jvalue(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,8 @@ using Test
 is_ci() = lowercase(get(ENV, "CI", "false")) == "true"
 
 if !is_ci() # only test if not CI
-include("engine.jl")
-include("matfile.jl")
-include("matstr.jl")
-include("mxarray.jl")
+    include("engine.jl")
+    include("matfile.jl")
+    include("matstr.jl")
+    include("mxarray.jl")
 end


### PR DESCRIPTION
Adds a conversion method to convert Julia abstract array to mxarray to avoid having them treated as structs in MATLAB.

Example:
```julia
a = transpose(rand(10)) # transpose
x = mxarray(a) # x is an actual matrix in matlab, was a struct before
y = jvalue(x) # the return value is now a matrix instead of a dictionary
```

Related issue #196 