### PR TITLE
Add path workaround for Linux

### DIFF
--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -81,7 +81,7 @@ function __init__()
 
     # load libraries
     # workaround for https://github.com/JuliaInterop/MATLAB.jl/issues/200
-    if Sys.iswindows()
+    if Sys.iswindows() || Sys.islinux()
         ENV["PATH"] = string(matlab_libpath, ";", ENV["PATH"])
     end
     libmx[]  = Libdl.dlopen(joinpath(matlab_libpath, "libmx"), Libdl.RTLD_GLOBAL)

--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -81,8 +81,10 @@ function __init__()
 
     # load libraries
     # workaround for https://github.com/JuliaInterop/MATLAB.jl/issues/200
-    if Sys.iswindows() || Sys.islinux()
+    if Sys.iswindows()
         ENV["PATH"] = string(matlab_libpath, ";", ENV["PATH"])
+    elseif Sys.islinux()
+        ENV["PATH"] = string(matlab_libpath, ":", ENV["PATH"])
     end
     libmx[]  = Libdl.dlopen(joinpath(matlab_libpath, "libmx"), Libdl.RTLD_GLOBAL)
     libmat[] = Libdl.dlopen(joinpath(matlab_libpath, "libmat"), Libdl.RTLD_GLOBAL)


### PR DESCRIPTION
## Description
Exactly the same as https://github.com/JuliaInterop/MATLAB.jl/pull/226, but for Linux. Tested and found out that it works too. 

Related to:
- https://github.com/JuliaInterop/MATLAB.jl/issues/200
- https://github.com/JuliaInterop/MATLAB.jl/issues/201
- https://github.com/JuliaInterop/MATLAB.jl/issues/220


## Before
```julia
julia> mat"version"

[1135198] signal 11 (1): Segmentation fault
in expression starting at REPL[3]:1
Allocations: 8630736 (Pool: 8629112; Big: 1624); GC: 9
Segmentation fault (core dumped)
```

## After
```julia
julia> mat"version"
"24.2.0.2806996 (R2024b) Update 3"
```