### PR TITLE
Update warning message for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This package is composed of two aspects:
 
 ### Windows
 
-1. For Matlab R2020a onwards, you should be able to go directly to step 2. If you encounter issues, run `matlab -batch "comserver('register')"` in the command prompt. For earlier versions of Matlab, start a command prompt as an administrator and enter `matlab /regserver`.
+1. For Matlab R2020a onwards, you should be able to go directly to step 2. If you encounter issues, run `matlab -batch "comserver('register')"` in the command prompt. For earlier versions of Matlab, start a command prompt as an administrator and enter `matlab /regserver`. Alternatively, you can do the same using the MATLAB GUI. To do this, open MATLAB with administrative privileges and run the following command in the MATLAB command window: `!matlab -regserver`. Close MATLAB and restart Julia.
 
 2. From Julia run: `Pkg.add("MATLAB")`
 
@@ -73,6 +73,17 @@ If you had the package `MATLAB.jl` already installed and built before changing t
 ```julia
 julia> using Pkg; Pkg.build("MATLAB")
 ```
+
+### Notes for Windows Users
+
+If you are using Windows, MATLAB needs to register its COM interface to properly work with MATLAB.jl. This should happen automatically during installation, but if you encounter issues, you can manually re-register MATLAB (with the version you want to use). To do this
+
+1. Open a MATLAB window with administrative privileges
+2. Run the following command in the MATLAB command window: `!matlab -regserver`
+3. Close MATLAB and restart Julia
+
+> [!IMPORTANT]
+> The version of MATLAB that is registered must be same that `MATLAB.jl` uses.
 
 
 


### PR DESCRIPTION
Adds additional information for Windows users.

A lot of trouble that windows users seem to have is that the engine API works differently on Windows.

According to Mathworks docs:
Instead of launching a new process (like on Mac/Linux) it opens a COM channel __to the version of MATLAB that is registered__ in Windows. If multiple MATLAB versions are used or MATLAB was updated, it can be that the version Julia uses is not the same that is registered in Windows.

There are two options:
1. Use version that is registered (rebuild MATLAB.jl) - but its unclear to find out __which version is registered__.
2. Open a specific MATLAB version and manually register it. Then adapt MATLAB.jl (if needed)

Until we can do option 1 automatically, I think for users, its easier to perform option 2. I added the instructions into the warning that is printed. 

The old instruction suggested doing this in an command prompt but additional information were missing _how_ to control the version that is actually getting registered. To make it smoother and avoid confusion, I think the graphical way is better suited and I removed the mention of the CLI way.

Closes #167 

Related: #182 


Relevant docs from Mathworks:
- Behaviour on Windows: https://de.mathworks.com/help/matlab/apiref/engopen.html
- Manually register: https://de.mathworks.com/help/matlab/matlab_external/registering-matlab-software-as-a-com-server.html